### PR TITLE
Increase HTTP client timeout from 1 to 3 minutes

### DIFF
--- a/req.go
+++ b/req.go
@@ -124,7 +124,7 @@ func (c *client) do(url string, method string, requestBody interface{}, result i
 		}
 
 		client := &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: 3 * time.Minute,
 		}
 		if c.token != "" {
 			r.Header.Add("Authorization", "Bearer "+c.token)


### PR DESCRIPTION
Some actions, such as listing requests, can take quite some time when
enough resources have accumulated.

This is rather a quick fix hoping for a proper configuration
possibility to be added in a larger overhaul coming soon.