### PR TITLE
Update request filters

### DIFF
--- a/request.go
+++ b/request.go
@@ -139,7 +139,32 @@ func (f *RequestListFilter) AddRequestStatus(requestStatus string) {
 
 // WithRequestStatus adds a requestStatus filter to the request list filter returning the filter for chaining
 func (f *RequestListFilter) WithRequestStatus(requestStatus string) *RequestListFilter {
-	f.Add("filter.requestStatus", requestStatus)
+	f.Add("filter.status", requestStatus)
+	return f
+}
+
+const timeFormat = "2006-01-02 15:04:05"
+
+// AddCreatedAfter adds a createdAfter filter to the request list filter
+func (f *RequestListFilter) AddCreatedAfter(t time.Time) {
+	f.WithCreatedAfter(t)
+}
+
+// WithCreatedAfter adds a createdAfter filter to the request list filter returning the filter for chaining
+func (f *RequestListFilter) WithCreatedAfter(t time.Time) *RequestListFilter {
+	f.Add("filter.createdAfter", t.Format(timeFormat))
+	return f
+}
+
+// AddCreatedBefore adds a createdBefore filter to the request list filter
+func (f *RequestListFilter) AddCreatedBefore(t time.Time) *RequestListFilter {
+	f.WithCreatedBefore(t)
+	return f
+}
+
+// WithCreatedBefore adds a createdBefore filter to the request list filter returning the filter for chaining
+func (f *RequestListFilter) WithCreatedBefore(t time.Time) *RequestListFilter {
+	f.Add("filter.createdBefore", t.Format(timeFormat))
 	return f
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -107,4 +108,26 @@ func (s *SuiteWaitTillRequests) Test_Err_GetStatusError() {
 	err := s.client.WaitTillRequestsFinished(context.Background(), nil)
 	s.Error(err)
 	s.Equal(2, httpmock.GetTotalCallCount())
+}
+
+func TestRequestListFilter_AddCreatedAfter(t *testing.T) {
+	r := NewRequestListFilter()
+	tm, err := time.Parse(timeFormat, "2019-03-25 10:40:00")
+	assert.NoError(t, err)
+	r.AddCreatedAfter(tm)
+	assert.Equal(t, "2019-03-25 10:40:00", r.Get("filter.createdAfter"))
+}
+
+func TestRequestListFilter_AddCreatedBefore(t *testing.T) {
+	r := NewRequestListFilter()
+	tm, err := time.Parse(timeFormat, "2019-03-25 10:40:00")
+	assert.NoError(t, err)
+	r.AddCreatedBefore(tm)
+	assert.Equal(t, "2019-03-25 10:40:00", r.Get("filter.createdBefore"))
+}
+
+func TestRequestListFilter_AddRequestStatus(t *testing.T) {
+	r := NewRequestListFilter()
+	r.AddRequestStatus("DONE")
+	assert.Equal(t, "DONE", r.Get("filter.status"))
 }


### PR DESCRIPTION
With the new ionos enterprise cloud api version, additional filters
are possible: createdBefore and createdAfter. requestStatus has
been renamed to status.