### PR TITLE
Marshal entities of k8s clusters

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -45,7 +45,7 @@ type KubernetesCluster struct {
 	PBType string `json:"type,omitempty"`
 
 	// Entities of a cluster
-	Entities KubernetesClusterEntities `json:"-"`
+	Entities KubernetesClusterEntities `json:"entities:omitempty"`
 }
 
 type KubernetesClusterEntities struct {


### PR DESCRIPTION
PR #57 changed the json tag to ignore the entities field of k8s clusters, which is ok regarding the swagger spec, but the api differs here. The content is actually delivered, so the swagger spec should be updated.