### PR TITLE
Fix go module importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export PATH=$PATH:$GOBIN
 The following `go` command will download `profitbricks-sdk-go` to your configured `GOPATH`:
 
 ```go
-go get "github.com/profitbricks/profitbricks-sdk-go"
+go get "github.com/profitbricks/profitbricks-sdk-go/v5"
 ```
 
 The source code of the package will be located here:
@@ -199,8 +199,9 @@ Include the ProfitBricks SDK for Go under the list of imports.
 
 ```go
 import(
-    "fmt"
-	"github.com/profitbricks/profitbricks-sdk-go"
+	"fmt"
+
+	"github.com/profitbricks/profitbricks-sdk-go/v5"
 )
 ```
 
@@ -217,9 +218,9 @@ It might be necessary to accept credentials through environment variables in a c
 ```go
 import (
 	"fmt"
-    "os"
+	"os"
 
-	"github.com/profitbricks/profitbricks-sdk-go"
+	"github.com/profitbricks/profitbricks-sdk-go/v5"
 )
 
 func main() {
@@ -294,7 +295,7 @@ client.SetDepth(3)
 Set Cloud API URL:
 
 ```go
-client.SetURL("https://api.profitbricks.com/cloudapi/v4")
+client.SetURL("https://api.profitbricks.com/cloudapi/v5")
 ```
 
 #### SetUserAgent
@@ -2809,7 +2810,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/profitbricks/profitbricks-sdk-go"
+	"github.com/profitbricks/profitbricks-sdk-go/v5"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/profitbricks/profitbricks-sdk-go
+module github.com/profitbricks/profitbricks-sdk-go/v5
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/integration-tests/datacenter_integration_test.go
+++ b/integration-tests/datacenter_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/firewallrule_integration_test.go
+++ b/integration-tests/firewallrule_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/helpers_test.go
+++ b/integration-tests/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 )
 
 var (

--- a/integration-tests/ipblock_integration_test.go
+++ b/integration-tests/ipblock_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/lan_integration_test.go
+++ b/integration-tests/lan_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/loadbalancer_integration_test.go
+++ b/integration-tests/loadbalancer_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/nic_integration_test.go
+++ b/integration-tests/nic_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/request_integration_test.go
+++ b/integration-tests/request_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/server_integration_test.go
+++ b/integration-tests/server_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/snapshot_integration_test.go
+++ b/integration-tests/snapshot_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/usermanagment_integration_test.go
+++ b/integration-tests/usermanagment_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integration-tests/volume_integration_test.go
+++ b/integration-tests/volume_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	sdk "github.com/profitbricks/profitbricks-sdk-go"
+	sdk "github.com/profitbricks/profitbricks-sdk-go/v5"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Go modules with a version higher than 1 require the version in the import path or `go get ` will fail.