### PR TITLE
Embed Metadata

### DIFF
--- a/backupunit.go
+++ b/backupunit.go
@@ -33,7 +33,7 @@ type BackupUnit struct {
 
 	// The metadata for the backup unit
 	// Read Only: true
-	Metadata *Metadata `json:"metadata,omitempty"`
+	*Metadata `json:"metadata,omitempty"`
 
 	Properties *BackupUnitProperties `json:"properties,omitempty"`
 }

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,1 @@
+package profitbricks

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,26 @@
+package profitbricks
+
+import "testing"
+
+func Test_cache_Add(t *testing.T) {
+	type fields struct {
+		typeCache map[string]map[string]cachable
+	}
+	type args struct {
+		obj cachable
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				typeCache: tt.fields.typeCache,
+			}
+		})
+	}
+}

--- a/datacenter.go
+++ b/datacenter.go
@@ -6,26 +6,14 @@ import (
 
 // Datacenter represents Virtual Data Center
 type Datacenter struct {
-	ID         string               `json:"id,omitempty"`
-	PBType     string               `json:"type,omitempty"`
-	Href       string               `json:"href,omitempty"`
-	Metadata   *Metadata            `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties DatacenterProperties `json:"properties,omitempty"`
 	Entities   DatacenterEntities   `json:"entities,omitempty"`
 	Response   string               `json:"Response,omitempty"`
 	Headers    *http.Header         `json:"headers,omitempty"`
-}
-
-// Metadata represents metadata recieved from Cloud API
-type Metadata struct {
-	CreatedDate          string `json:"createdDate,omitempty"`
-	CreatedBy            string `json:"createdBy,omitempty"`
-	CreatedByUserID      string `json:"createdByUserId,omitempty"`
-	Etag                 string `json:"etag,omitempty"`
-	LastModifiedDate     string `json:"lastModifiedDate,omitempty"`
-	LastModifiedBy       string `json:"lastModifiedBy,omitempty"`
-	LastModifiedByUserID string `json:"lastModifiedByUserId,omitempty"`
-	State                string `json:"state,omitempty"`
 }
 
 // DatacenterProperties represents Virtual Data Center properties

--- a/firewallrule.go
+++ b/firewallrule.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-//FirewallRule object
+// FirewallRule object
 type FirewallRule struct {
-	ID         string                 `json:"id,omitempty"`
-	PBType     string                 `json:"type,omitempty"`
-	Href       string                 `json:"href,omitempty"`
-	Metadata   *Metadata              `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties FirewallruleProperties `json:"properties,omitempty"`
 	Response   string                 `json:"Response,omitempty"`
 	Headers    *http.Header           `json:"headers,omitempty"`
 	StatusCode int                    `json:"statuscode,omitempty"`
 }
 
-//FirewallruleProperties object
+// FirewallruleProperties object
 type FirewallruleProperties struct {
 	Name           string  `json:"name,omitempty"`
 	Protocol       string  `json:"protocol,omitempty"`
@@ -29,7 +29,7 @@ type FirewallruleProperties struct {
 	PortRangeEnd   *int    `json:"portRangeEnd,omitempty"`
 }
 
-//FirewallRules object
+// FirewallRules object
 type FirewallRules struct {
 	ID         string         `json:"id,omitempty"`
 	PBType     string         `json:"type,omitempty"`
@@ -40,7 +40,7 @@ type FirewallRules struct {
 	StatusCode int            `json:"statuscode,omitempty"`
 }
 
-//ListFirewallRules lists all firewall rules
+// ListFirewallRules lists all firewall rules
 func (c *Client) ListFirewallRules(dcID string, serverID string, nicID string) (*FirewallRules, error) {
 	url := firewallRulesPath(dcID, serverID, nicID)
 	ret := &FirewallRules{}
@@ -48,7 +48,7 @@ func (c *Client) ListFirewallRules(dcID string, serverID string, nicID string) (
 	return ret, err
 }
 
-//GetFirewallRule gets a firewall rule
+// GetFirewallRule gets a firewall rule
 func (c *Client) GetFirewallRule(dcID string, serverID string, nicID string, fwID string) (*FirewallRule, error) {
 	url := firewallRulePath(dcID, serverID, nicID, fwID)
 	ret := &FirewallRule{}
@@ -56,7 +56,7 @@ func (c *Client) GetFirewallRule(dcID string, serverID string, nicID string, fwI
 	return ret, err
 }
 
-//CreateFirewallRule creates a firewall rule
+// CreateFirewallRule creates a firewall rule
 func (c *Client) CreateFirewallRule(dcID string, serverID string, nicID string, fw FirewallRule) (*FirewallRule, error) {
 	url := firewallRulesPath(dcID, serverID, nicID)
 	ret := &FirewallRule{}
@@ -64,7 +64,7 @@ func (c *Client) CreateFirewallRule(dcID string, serverID string, nicID string, 
 	return ret, err
 }
 
-//UpdateFirewallRule updates a firewall rule
+// UpdateFirewallRule updates a firewall rule
 func (c *Client) UpdateFirewallRule(dcID string, serverID string, nicID string, fwID string, obj FirewallruleProperties) (*FirewallRule, error) {
 	url := firewallRulePath(dcID, serverID, nicID, fwID)
 	ret := &FirewallRule{}
@@ -72,7 +72,7 @@ func (c *Client) UpdateFirewallRule(dcID string, serverID string, nicID string, 
 	return ret, err
 }
 
-//DeleteFirewallRule deletes a firewall rule
+// DeleteFirewallRule deletes a firewall rule
 func (c *Client) DeleteFirewallRule(dcID string, serverID string, nicID string, fwID string) (*http.Header, error) {
 	url := firewallRulePath(dcID, serverID, nicID, fwID)
 	ret := &http.Header{}

--- a/image.go
+++ b/image.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-//Image object
+// Image object
 type Image struct {
-	ID         string          `json:"id,omitempty"`
-	PBType     string          `json:"type,omitempty"`
-	Href       string          `json:"href,omitempty"`
-	Metadata   *Metadata       `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties ImageProperties `json:"properties,omitempty"`
 	Response   string          `json:"Response,omitempty"`
 	Headers    *http.Header    `json:"headers,omitempty"`
 	StatusCode int             `json:"statuscode,omitempty"`
 }
 
-//ImageProperties object
+// ImageProperties object
 type ImageProperties struct {
 	Name                string       `json:"name,omitempty"`
 	Description         string       `json:"description,omitempty"`
@@ -41,7 +41,7 @@ type ImageProperties struct {
 	StatusCode          int          `json:"statuscode,omitempty"`
 }
 
-//Images object
+// Images object
 type Images struct {
 	ID         string       `json:"id,omitempty"`
 	PBType     string       `json:"type,omitempty"`
@@ -52,7 +52,7 @@ type Images struct {
 	StatusCode int          `json:"statuscode,omitempty"`
 }
 
-//Cdroms object
+// Cdroms object
 type Cdroms struct {
 	ID         string       `json:"id,omitempty"`
 	PBType     string       `json:"type,omitempty"`

--- a/ipblock.go
+++ b/ipblock.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-//IPBlock object
+// IPBlock object
 type IPBlock struct {
-	ID         string            `json:"id,omitempty"`
-	PBType     string            `json:"type,omitempty"`
-	Href       string            `json:"href,omitempty"`
-	Metadata   *Metadata         `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties IPBlockProperties `json:"properties,omitempty"`
 	Response   string            `json:"Response,omitempty"`
 	Headers    *http.Header      `json:"headers,omitempty"`
 	StatusCode int               `json:"statuscode,omitempty"`
 }
 
-//IPBlockProperties object
+// IPBlockProperties object
 type IPBlockProperties struct {
 	Name        string       `json:"name,omitempty"`
 	IPs         []string     `json:"ips,omitempty"`
@@ -35,7 +35,7 @@ type IPConsumer struct {
 	DatacenterName string `json:"datacenterName,omitempty"`
 }
 
-//IPBlocks object
+// IPBlocks object
 type IPBlocks struct {
 	ID         string       `json:"id,omitempty"`
 	PBType     string       `json:"type,omitempty"`
@@ -46,7 +46,7 @@ type IPBlocks struct {
 	StatusCode int          `json:"statuscode,omitempty"`
 }
 
-//ListIPBlocks lists all IP blocks
+// ListIPBlocks lists all IP blocks
 func (c *Client) ListIPBlocks() (*IPBlocks, error) {
 	url := ipblocksPath()
 	ret := &IPBlocks{}
@@ -54,7 +54,7 @@ func (c *Client) ListIPBlocks() (*IPBlocks, error) {
 	return ret, err
 }
 
-//ReserveIPBlock creates an IP block
+// ReserveIPBlock creates an IP block
 func (c *Client) ReserveIPBlock(request IPBlock) (*IPBlock, error) {
 	url := ipblocksPath()
 	ret := &IPBlock{}
@@ -62,7 +62,7 @@ func (c *Client) ReserveIPBlock(request IPBlock) (*IPBlock, error) {
 	return ret, err
 }
 
-//GetIPBlock gets an IP blocks
+// GetIPBlock gets an IP blocks
 func (c *Client) GetIPBlock(ipblockid string) (*IPBlock, error) {
 	url := ipblockPath(ipblockid)
 	ret := &IPBlock{}
@@ -78,7 +78,7 @@ func (c *Client) UpdateIPBlock(ipblockid string, props IPBlockProperties) (*IPBl
 	return ret, err
 }
 
-//ReleaseIPBlock deletes an IP block
+// ReleaseIPBlock deletes an IP block
 func (c *Client) ReleaseIPBlock(ipblockid string) (*http.Header, error) {
 	url := ipblockPath(ipblockid)
 	ret := &http.Header{}

--- a/k8s.go
+++ b/k8s.go
@@ -33,7 +33,7 @@ type KubernetesCluster struct {
 	ID string `json:"id,omitempty"`
 
 	// metadata
-	Metadata *Metadata `json:"metadata,omitempty"`
+	*Metadata `json:"metadata,omitempty"`
 
 	// properties
 	// Required: true
@@ -59,7 +59,7 @@ type UpdatedKubernetesCluster struct {
 	ID string `json:"id,omitempty"`
 
 	// metadata
-	Metadata *Metadata `json:"metadata,omitempty"`
+	*Metadata `json:"metadata,omitempty"`
 
 	// properties
 	// Required: true
@@ -123,7 +123,7 @@ type KubernetesNodePool struct {
 	ID string `json:"id,omitempty"`
 
 	// metadata
-	Metadata *Metadata `json:"metadata,omitempty"`
+	*Metadata `json:"metadata,omitempty"`
 
 	// properties
 	// Required: true

--- a/lan.go
+++ b/lan.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 )
 
-//Lan object
+// Lan object
 type Lan struct {
-	ID         string        `json:"id,omitempty"`
-	PBType     string        `json:"type,omitempty"`
-	Href       string        `json:"href,omitempty"`
-	Metadata   *Metadata     `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties LanProperties `json:"properties,omitempty"`
 	Entities   *LanEntities  `json:"entities,omitempty"`
 	Response   string        `json:"Response,omitempty"`
@@ -17,25 +17,25 @@ type Lan struct {
 	StatusCode int           `json:"statuscode,omitempty"`
 }
 
-//LanProperties object
+// LanProperties object
 type LanProperties struct {
 	Name       string        `json:"name,omitempty"`
 	Public     bool          `json:"public,omitempty"`
 	IPFailover *[]IPFailover `json:"ipFailover,omitempty"`
 }
 
-//LanEntities object
+// LanEntities object
 type LanEntities struct {
 	Nics *LanNics `json:"nics,omitempty"`
 }
 
-//IPFailover object
+// IPFailover object
 type IPFailover struct {
 	NicUUID string `json:"nicUuid,omitempty"`
 	IP      string `json:"ip,omitempty"`
 }
 
-//LanNics object
+// LanNics object
 type LanNics struct {
 	ID     string `json:"id,omitempty"`
 	PBType string `json:"type,omitempty"`
@@ -43,7 +43,7 @@ type LanNics struct {
 	Items  []Nic  `json:"items,omitempty"`
 }
 
-//Lans object
+// Lans object
 type Lans struct {
 	ID         string       `json:"id,omitempty"`
 	PBType     string       `json:"type,omitempty"`

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 )
 
-//Loadbalancer object
+// Loadbalancer object
 type Loadbalancer struct {
-	ID         string                 `json:"id,omitempty"`
-	PBType     string                 `json:"type,omitempty"`
-	Href       string                 `json:"href,omitempty"`
-	Metadata   *Metadata              `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties LoadbalancerProperties `json:"properties,omitempty"`
 	Entities   LoadbalancerEntities   `json:"entities,omitempty"`
 	Response   string                 `json:"Response,omitempty"`
@@ -17,19 +17,19 @@ type Loadbalancer struct {
 	StatusCode int                    `json:"statuscode,omitempty"`
 }
 
-//LoadbalancerProperties object
+// LoadbalancerProperties object
 type LoadbalancerProperties struct {
 	Name string `json:"name,omitempty"`
 	IP   string `json:"ip,omitempty"`
 	Dhcp bool   `json:"dhcp,omitempty"`
 }
 
-//LoadbalancerEntities object
+// LoadbalancerEntities object
 type LoadbalancerEntities struct {
 	Balancednics *BalancedNics `json:"balancednics,omitempty"`
 }
 
-//BalancedNics object
+// BalancedNics object
 type BalancedNics struct {
 	ID     string `json:"id,omitempty"`
 	PBType string `json:"type,omitempty"`
@@ -37,7 +37,7 @@ type BalancedNics struct {
 	Items  []Nic  `json:"items,omitempty"`
 }
 
-//Loadbalancers object
+// Loadbalancers object
 type Loadbalancers struct {
 	ID     string         `json:"id,omitempty"`
 	PBType string         `json:"type,omitempty"`
@@ -49,7 +49,7 @@ type Loadbalancers struct {
 	StatusCode int          `json:"statuscode,omitempty"`
 }
 
-//ListLoadbalancers returns a Collection struct for loadbalancers in the Datacenter
+// ListLoadbalancers returns a Collection struct for loadbalancers in the Datacenter
 func (c *Client) ListLoadbalancers(dcid string) (*Loadbalancers, error) {
 
 	url := loadbalancersPath(dcid)
@@ -58,7 +58,7 @@ func (c *Client) ListLoadbalancers(dcid string) (*Loadbalancers, error) {
 	return ret, err
 }
 
-//CreateLoadbalancer creates a loadbalancer in the datacenter from a jason []byte and returns a Instance struct
+// CreateLoadbalancer creates a loadbalancer in the datacenter from a jason []byte and returns a Instance struct
 func (c *Client) CreateLoadbalancer(dcid string, request Loadbalancer) (*Loadbalancer, error) {
 	url := loadbalancersPath(dcid)
 	ret := &Loadbalancer{}
@@ -67,7 +67,7 @@ func (c *Client) CreateLoadbalancer(dcid string, request Loadbalancer) (*Loadbal
 	return ret, err
 }
 
-//GetLoadbalancer pulls data for the Loadbalancer  where id = lbalid returns a Instance struct
+// GetLoadbalancer pulls data for the Loadbalancer  where id = lbalid returns a Instance struct
 func (c *Client) GetLoadbalancer(dcid, lbalid string) (*Loadbalancer, error) {
 	url := loadbalancerPath(dcid, lbalid)
 	ret := &Loadbalancer{}
@@ -75,7 +75,7 @@ func (c *Client) GetLoadbalancer(dcid, lbalid string) (*Loadbalancer, error) {
 	return ret, err
 }
 
-//UpdateLoadbalancer updates a load balancer
+// UpdateLoadbalancer updates a load balancer
 func (c *Client) UpdateLoadbalancer(dcid string, lbalid string, obj LoadbalancerProperties) (*Loadbalancer, error) {
 	url := loadbalancerPath(dcid, lbalid)
 	ret := &Loadbalancer{}
@@ -83,7 +83,7 @@ func (c *Client) UpdateLoadbalancer(dcid string, lbalid string, obj Loadbalancer
 	return ret, err
 }
 
-//DeleteLoadbalancer deletes a load balancer
+// DeleteLoadbalancer deletes a load balancer
 func (c *Client) DeleteLoadbalancer(dcid, lbalid string) (*http.Header, error) {
 	url := loadbalancerPath(dcid, lbalid)
 	ret := &http.Header{}
@@ -91,7 +91,7 @@ func (c *Client) DeleteLoadbalancer(dcid, lbalid string) (*http.Header, error) {
 	return ret, err
 }
 
-//ListBalancedNics lists balanced nics
+// ListBalancedNics lists balanced nics
 func (c *Client) ListBalancedNics(dcid, lbalid string) (*Nics, error) {
 	url := balancedNicsPath(dcid, lbalid)
 	ret := &Nics{}
@@ -99,7 +99,7 @@ func (c *Client) ListBalancedNics(dcid, lbalid string) (*Nics, error) {
 	return ret, err
 }
 
-//AssociateNic attach a nic to load balancer
+// AssociateNic attach a nic to load balancer
 func (c *Client) AssociateNic(dcid string, lbalid string, nicid string) (*Nic, error) {
 	sm := map[string]string{"id": nicid}
 	url := balancedNicsPath(dcid, lbalid)
@@ -108,7 +108,7 @@ func (c *Client) AssociateNic(dcid string, lbalid string, nicid string) (*Nic, e
 	return ret, err
 }
 
-//GetBalancedNic gets a balanced nic
+// GetBalancedNic gets a balanced nic
 func (c *Client) GetBalancedNic(dcid, lbalid, balnicid string) (*Nic, error) {
 	url := balancedNicPath(dcid, lbalid, balnicid)
 	ret := &Nic{}
@@ -116,7 +116,7 @@ func (c *Client) GetBalancedNic(dcid, lbalid, balnicid string) (*Nic, error) {
 	return ret, err
 }
 
-//DeleteBalancedNic removes a balanced nic
+// DeleteBalancedNic removes a balanced nic
 func (c *Client) DeleteBalancedNic(dcid, lbalid, balnicid string) (*http.Header, error) {
 	url := balancedNicPath(dcid, lbalid, balnicid)
 	ret := &http.Header{}

--- a/location.go
+++ b/location.go
@@ -10,7 +10,6 @@ type Location struct {
 	ID         string             `json:"id,omitempty"`
 	PBType     string             `json:"type,omitempty"`
 	Href       string             `json:"href,omitempty"`
-	Metadata   Metadata           `json:"metadata,omitempty"`
 	Properties LocationProperties `json:"properties,omitempty"`
 	Response   string             `json:"Response,omitempty"`
 	Headers    *http.Header       `json:"headers,omitempty"`

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,18 @@
+package profitbricks
+
+// Metadata represents metadata recieved from Cloud API
+type Metadata struct {
+	CreatedDate          string `json:"createdDate,omitempty"`
+	CreatedBy            string `json:"createdBy,omitempty"`
+	CreatedByUserID      string `json:"createdByUserId,omitempty"`
+	Etag                 string `json:"etag,omitempty"`
+	LastModifiedDate     string `json:"lastModifiedDate,omitempty"`
+	LastModifiedBy       string `json:"lastModifiedBy,omitempty"`
+	LastModifiedByUserID string `json:"lastModifiedByUserId,omitempty"`
+	State                string `json:"state,omitempty"`
+}
+
+// GetMetadata returns the metadata of the embedding object
+func (m *Metadata) GetMetadata() *Metadata {
+	return m
+}

--- a/model.go
+++ b/model.go
@@ -6,21 +6,21 @@ package profitbricks
 
 import "net/http"
 
-type Header struct {
+type Headers struct {
 	Headers *http.Header
 }
 
 // GetHeader to be interfaceable
-func (h *Header) GetHeader() *http.Header {
+func (h *Headers) GetHeader() *http.Header {
 	return h.Headers
 }
 
 // SetHeader to be interfaceable
-func (h *Header) SetHeader(header *http.Header) {
+func (h *Headers) SetHeader(header *http.Header) {
 	h.Headers = header
 }
 
 // Get returns the actual value for given header key
-func (h *Header) Get(key string) string {
+func (h *Headers) Get(key string) string {
 	return h.Headers.Get(key)
 }

--- a/nic.go
+++ b/nic.go
@@ -6,10 +6,10 @@ import (
 
 // Nic object
 type Nic struct {
-	ID         string         `json:"id,omitempty"`
-	PBType     string         `json:"type,omitempty"`
-	Href       string         `json:"href,omitempty"`
-	Metadata   *Metadata      `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties *NicProperties `json:"properties,omitempty"`
 	Entities   *NicEntities   `json:"entities,omitempty"`
 	Response   string         `json:"Response,omitempty"`

--- a/s3key.go
+++ b/s3key.go
@@ -33,7 +33,7 @@ type S3Key struct {
 
 	// The metadata for the S3 key
 	// Read Only: true
-	Metadata *Metadata `json:"metadata,omitempty"`
+	*Metadata `json:"metadata,omitempty"`
 
 	// The properties of the S3 key
 	// Read Only: false

--- a/server.go
+++ b/server.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 )
 
-//Server object
+// Server object
 type Server struct {
-	ID         string           `json:"id,omitempty"`
-	PBType     string           `json:"type,omitempty"`
-	Href       string           `json:"href,omitempty"`
-	Metadata   *Metadata        `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties ServerProperties `json:"properties,omitempty"`
 	Entities   *ServerEntities  `json:"entities,omitempty"`
 	Response   string           `json:"Response,omitempty"`
@@ -17,7 +17,7 @@ type Server struct {
 	StatusCode int              `json:"statuscode,omitempty"`
 }
 
-//ServerProperties object
+// ServerProperties object
 type ServerProperties struct {
 	Name             string             `json:"name,omitempty"`
 	Cores            int                `json:"cores,omitempty"`
@@ -29,14 +29,14 @@ type ServerProperties struct {
 	CPUFamily        string             `json:"cpuFamily,omitempty"`
 }
 
-//ServerEntities object
+// ServerEntities object
 type ServerEntities struct {
 	Cdroms  *Cdroms  `json:"cdroms,omitempty"`
 	Volumes *Volumes `json:"volumes,omitempty"`
 	Nics    *Nics    `json:"nics,omitempty"`
 }
 
-//Servers collection
+// Servers collection
 type Servers struct {
 	ID         string       `json:"id,omitempty"`
 	PBType     string       `json:"type,omitempty"`
@@ -47,7 +47,7 @@ type Servers struct {
 	StatusCode int          `json:"statuscode,omitempty"`
 }
 
-//ResourceReference object
+// ResourceReference object
 type ResourceReference struct {
 	ID     string `json:"id,omitempty"`
 	PBType string `json:"type,omitempty"`
@@ -94,7 +94,7 @@ func (c *Client) DeleteServer(dcid, srvid string) (*http.Header, error) {
 	return ret, err
 }
 
-//ListAttachedCdroms returns list of attached cd roms
+// ListAttachedCdroms returns list of attached cd roms
 func (c *Client) ListAttachedCdroms(dcid, srvid string) (*Images, error) {
 	url := cdromsPath(dcid, srvid)
 	ret := &Images{}
@@ -102,7 +102,7 @@ func (c *Client) ListAttachedCdroms(dcid, srvid string) (*Images, error) {
 	return ret, err
 }
 
-//AttachCdrom attaches a CD rom
+// AttachCdrom attaches a CD rom
 func (c *Client) AttachCdrom(dcid string, srvid string, cdid string) (*Image, error) {
 	data := struct {
 		ID string `json:"id,omitempty"`
@@ -115,7 +115,7 @@ func (c *Client) AttachCdrom(dcid string, srvid string, cdid string) (*Image, er
 	return ret, err
 }
 
-//GetAttachedCdrom gets attached cd roms
+// GetAttachedCdrom gets attached cd roms
 func (c *Client) GetAttachedCdrom(dcid, srvid, cdid string) (*Image, error) {
 	url := cdromPath(dcid, srvid, cdid)
 	ret := &Image{}
@@ -123,7 +123,7 @@ func (c *Client) GetAttachedCdrom(dcid, srvid, cdid string) (*Image, error) {
 	return ret, err
 }
 
-//DetachCdrom detaches a CD rom
+// DetachCdrom detaches a CD rom
 func (c *Client) DetachCdrom(dcid, srvid, cdid string) (*http.Header, error) {
 	url := cdromPath(dcid, srvid, cdid)
 	ret := &http.Header{}
@@ -131,7 +131,7 @@ func (c *Client) DetachCdrom(dcid, srvid, cdid string) (*http.Header, error) {
 	return ret, err
 }
 
-//ListAttachedVolumes lists attached volumes
+// ListAttachedVolumes lists attached volumes
 func (c *Client) ListAttachedVolumes(dcid, srvid string) (*Volumes, error) {
 	url := attachedVolumesPath(dcid, srvid)
 	ret := &Volumes{}
@@ -139,7 +139,7 @@ func (c *Client) ListAttachedVolumes(dcid, srvid string) (*Volumes, error) {
 	return ret, err
 }
 
-//AttachVolume attaches a volume
+// AttachVolume attaches a volume
 func (c *Client) AttachVolume(dcid string, srvid string, volid string) (*Volume, error) {
 	data := struct {
 		ID string `json:"id,omitempty"`
@@ -153,7 +153,7 @@ func (c *Client) AttachVolume(dcid string, srvid string, volid string) (*Volume,
 	return ret, err
 }
 
-//GetAttachedVolume gets an attached volume
+// GetAttachedVolume gets an attached volume
 func (c *Client) GetAttachedVolume(dcid, srvid, volid string) (*Volume, error) {
 	url := attachedVolumePath(dcid, srvid, volid)
 	ret := &Volume{}
@@ -162,7 +162,7 @@ func (c *Client) GetAttachedVolume(dcid, srvid, volid string) (*Volume, error) {
 	return ret, err
 }
 
-//DetachVolume detaches a volume
+// DetachVolume detaches a volume
 func (c *Client) DetachVolume(dcid, srvid, volid string) (*http.Header, error) {
 	url := attachedVolumePath(dcid, srvid, volid)
 	ret := &http.Header{}
@@ -173,7 +173,7 @@ func (c *Client) DetachVolume(dcid, srvid, volid string) (*http.Header, error) {
 // StartServer starts a server
 func (c *Client) StartServer(dcid, srvid string) (*http.Header, error) {
 	url := serverStartPath(dcid, srvid)
-	ret := &Header{}
+	ret := &Headers{}
 	err := c.Post(url, nil, ret, http.StatusAccepted)
 	return ret.GetHeader(), err
 }
@@ -181,7 +181,7 @@ func (c *Client) StartServer(dcid, srvid string) (*http.Header, error) {
 // StopServer stops a server
 func (c *Client) StopServer(dcid, srvid string) (*http.Header, error) {
 	url := serverStopPath(dcid, srvid)
-	ret := &Header{}
+	ret := &Headers{}
 	err := c.Post(url, nil, ret, http.StatusAccepted)
 	return ret.GetHeader(), err
 }
@@ -189,7 +189,7 @@ func (c *Client) StopServer(dcid, srvid string) (*http.Header, error) {
 // RebootServer reboots a server
 func (c *Client) RebootServer(dcid, srvid string) (*http.Header, error) {
 	url := serverRebootPath(dcid, srvid)
-	ret := &Header{}
+	ret := &Headers{}
 	err := c.Post(url, nil, ret, http.StatusAccepted)
 	return ret.GetHeader(), err
 }

--- a/snapshot.go
+++ b/snapshot.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 )
 
-//Snapshot object
+// Snapshot object
 type Snapshot struct {
-	ID         string             `json:"id,omitempty"`
-	PBType     string             `json:"type,omitempty"`
-	Href       string             `json:"href,omitempty"`
-	Metadata   Metadata           `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties SnapshotProperties `json:"properties,omitempty"`
 	Response   string             `json:"Response,omitempty"`
 	Headers    *http.Header       `json:"headers,omitempty"`
@@ -35,7 +35,7 @@ type SnapshotProperties struct {
 	LicenceType         string `json:"licenceType,omitempty"`
 }
 
-//Snapshots object
+// Snapshots object
 type Snapshots struct {
 	ID         string       `json:"id,omitempty"`
 	PBType     string       `json:"type,omitempty"`
@@ -46,7 +46,7 @@ type Snapshots struct {
 	StatusCode int          `json:"statuscode,omitempty"`
 }
 
-//ListSnapshots lists all snapshots
+// ListSnapshots lists all snapshots
 func (c *Client) ListSnapshots() (*Snapshots, error) {
 	url := snapshotsPath()
 	ret := &Snapshots{}
@@ -54,7 +54,7 @@ func (c *Client) ListSnapshots() (*Snapshots, error) {
 	return ret, err
 }
 
-//GetSnapshot gets a specific snapshot
+// GetSnapshot gets a specific snapshot
 func (c *Client) GetSnapshot(snapshotID string) (*Snapshot, error) {
 	url := snapshotPath(snapshotID)
 	ret := &Snapshot{}

--- a/usermanagment.go
+++ b/usermanagment.go
@@ -60,10 +60,10 @@ type Users struct {
 
 // User object
 type User struct {
-	ID         string          `json:"id,omitempty"`
-	PBType     string          `json:"type,omitempty"`
-	Href       string          `json:"href,omitempty"`
-	Metadata   *Metadata       `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties *UserProperties `json:"properties,omitempty"`
 	Entities   *UserEntities   `json:"entities,omitempty"`
 	Response   string          `json:"Response,omitempty"`
@@ -101,10 +101,10 @@ type Resources struct {
 
 // Resource object
 type Resource struct {
-	ID         string            `json:"id,omitempty"`
-	PBType     string            `json:"type,omitempty"`
-	Href       string            `json:"href,omitempty"`
-	Metadata   *Metadata         `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Entities   *ResourceEntities `json:"entities,omitempty"`
 	Response   string            `json:"Response,omitempty"`
 	Headers    *http.Header      `json:"headers,omitempty"`
@@ -129,10 +129,10 @@ type Owns struct {
 
 // Entity object
 type Entity struct {
-	ID         string       `json:"id,omitempty"`
-	PBType     string       `json:"type,omitempty"`
-	Href       string       `json:"href,omitempty"`
-	Metadata   *Metadata    `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Response   string       `json:"Response,omitempty"`
 	Headers    *http.Header `json:"headers,omitempty"`
 	StatusCode int          `json:"statuscode,omitempty"`
@@ -166,7 +166,7 @@ type ShareProperties struct {
 	SharePrivilege *bool `json:"sharePrivilege,omitempty"`
 }
 
-//ListGroups lists all groups
+// ListGroups lists all groups
 func (c *Client) ListGroups() (*Groups, error) {
 	url := groupsPath()
 	ret := &Groups{}
@@ -174,7 +174,7 @@ func (c *Client) ListGroups() (*Groups, error) {
 	return ret, err
 }
 
-//GetGroup gets a group
+// GetGroup gets a group
 func (c *Client) GetGroup(groupid string) (*Group, error) {
 	url := groupPath(groupid)
 	ret := &Group{}
@@ -182,7 +182,7 @@ func (c *Client) GetGroup(groupid string) (*Group, error) {
 	return ret, err
 }
 
-//CreateGroup creates a group
+// CreateGroup creates a group
 func (c *Client) CreateGroup(grp Group) (*Group, error) {
 	url := groupsPath()
 	ret := &Group{}
@@ -190,7 +190,7 @@ func (c *Client) CreateGroup(grp Group) (*Group, error) {
 	return ret, err
 }
 
-//UpdateGroup updates a group
+// UpdateGroup updates a group
 func (c *Client) UpdateGroup(groupid string, obj Group) (*Group, error) {
 	url := groupPath(groupid)
 	ret := &Group{}
@@ -198,7 +198,7 @@ func (c *Client) UpdateGroup(groupid string, obj Group) (*Group, error) {
 	return ret, err
 }
 
-//DeleteGroup deletes a group
+// DeleteGroup deletes a group
 func (c *Client) DeleteGroup(groupid string) (*http.Header, error) {
 	url := groupPath(groupid)
 	ret := &http.Header{}
@@ -206,7 +206,7 @@ func (c *Client) DeleteGroup(groupid string) (*http.Header, error) {
 	return ret, err
 }
 
-//ListShares lists all shares
+// ListShares lists all shares
 func (c *Client) ListShares(grpid string) (*Shares, error) {
 	url := sharesPath(grpid)
 	ret := &Shares{}
@@ -246,7 +246,7 @@ func (c *Client) DeleteShare(groupid string, resourceid string) (*http.Header, e
 	return ret, err
 }
 
-//ListGroupUsers lists Users in a group
+// ListGroupUsers lists Users in a group
 func (c *Client) ListGroupUsers(groupid string) (*Users, error) {
 	url := groupUsersPath(groupid)
 	ret := &Users{}
@@ -272,7 +272,7 @@ func (c *Client) DeleteUserFromGroup(groupid string, userid string) (*http.Heade
 	return ret, err
 }
 
-//ListUsers lists all users
+// ListUsers lists all users
 func (c *Client) ListUsers() (*Users, error) {
 	url := usersPath()
 	ret := &Users{}
@@ -288,7 +288,7 @@ func (c *Client) GetUser(usrid string) (*User, error) {
 	return ret, err
 }
 
-//CreateUser creates a user
+// CreateUser creates a user
 func (c *Client) CreateUser(usr User) (*User, error) {
 	url := usersPath()
 	ret := &User{}
@@ -296,7 +296,7 @@ func (c *Client) CreateUser(usr User) (*User, error) {
 	return ret, err
 }
 
-//UpdateUser updates user information
+// UpdateUser updates user information
 func (c *Client) UpdateUser(userid string, obj User) (*User, error) {
 	url := userPath(userid)
 	ret := &User{}
@@ -304,7 +304,7 @@ func (c *Client) UpdateUser(userid string, obj User) (*User, error) {
 	return ret, err
 }
 
-//DeleteUser deletes the specified user
+// DeleteUser deletes the specified user
 func (c *Client) DeleteUser(userid string) (*http.Header, error) {
 	url := userPath(userid)
 	ret := &http.Header{}
@@ -312,7 +312,7 @@ func (c *Client) DeleteUser(userid string) (*http.Header, error) {
 	return ret, err
 }
 
-//ListResources lists all resources
+// ListResources lists all resources
 func (c *Client) ListResources() (*Resources, error) {
 	url := resourcesPath()
 	ret := &Resources{}
@@ -320,7 +320,7 @@ func (c *Client) ListResources() (*Resources, error) {
 	return ret, err
 }
 
-//GetResourceByType gets a resource by type
+// GetResourceByType gets a resource by type
 func (c *Client) GetResourceByType(resourcetype string, resourceid string) (*Resource, error) {
 	url := resourcePath(resourcetype, resourceid)
 	ret := &Resource{}
@@ -328,7 +328,7 @@ func (c *Client) GetResourceByType(resourcetype string, resourceid string) (*Res
 	return ret, err
 }
 
-//ListResourcesByType list resources by type
+// ListResourcesByType list resources by type
 func (c *Client) ListResourcesByType(resourcetype string) (*Resources, error) {
 	url := resourcesTypePath(resourcetype)
 	ret := &Resources{}

--- a/volume.go
+++ b/volume.go
@@ -8,10 +8,10 @@ import (
 
 // Volume object
 type Volume struct {
-	ID         string           `json:"id,omitempty"`
-	PBType     string           `json:"type,omitempty"`
-	Href       string           `json:"href,omitempty"`
-	Metadata   *Metadata        `json:"metadata,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PBType     string `json:"type,omitempty"`
+	Href       string `json:"href,omitempty"`
+	*Metadata  `json:"metadata,omitempty"`
 	Properties VolumeProperties `json:"properties,omitempty"`
 	Response   string           `json:"Response,omitempty"`
 	Headers    *http.Header     `json:"headers,omitempty"`
@@ -94,7 +94,7 @@ func (c *Client) CreateSnapshot(dcid string, volid string, name string, descript
 
 // RestoreSnapshot restores a volume with provided snapshot
 func (c *Client) RestoreSnapshot(dcid string, volid string, snapshotID string) (*http.Header, error) {
-	ret := &Header{}
+	ret := &Headers{}
 	req := c.Client.R().
 		SetFormData(map[string]string{"snapshotId": snapshotID}).
 		SetResult(ret)


### PR DESCRIPTION
Using an embedded structure brings the benefit of providing a new
GetMetadata method for embedding structs, which itself can than
be used for interfaces. As the etag attribute might be used for
caching data this will make implementation of a caching machism
easier.

While most of the changes are non breaking, 2 objects included
Metadata not as pointer, Location and Snapshots. Metadata in
location is likely based on a bug in the swagger doc as
no metadata is delivered & and documentation also does not
mention metadata for location.