### PR TITLE
Retry on BadGateway, GatewayTimeout and ServiceUnavailable

### DIFF
--- a/client.go
+++ b/client.go
@@ -91,6 +91,10 @@ func validateResponse(rsp *resty.Response, expectedStatus ...int) error {
 	if rsp.StatusCode() >= 400 {
 		e := rsp.Error().(*ApiError)
 		e.RawBody = rsp.Body()
+		// if content type was not json, the api error is empty
+		if e.HTTPStatus == 0 {
+			e.HTTPStatus = rsp.StatusCode()
+		}
 		return *e
 
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -2,11 +2,12 @@ package profitbricks
 
 import (
 	"bytes"
-	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/error_test.go
+++ b/error_test.go
@@ -2,12 +2,11 @@ package profitbricks
 
 import (
 	"bytes"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"net/http"
 	"testing"
-
-	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -105,6 +104,7 @@ func (s *ErrorSuite) Test_BadGatewayError() {
 		Status:     http.StatusText(http.StatusBadGateway),
 	}
 	mRsp.Header.Set("Content-Type", "text/html")
+	s.c.SetRetryCount(0)
 	httpmock.RegisterResponder(http.MethodGet, "=~/datacenters", httpmock.ResponderFromResponse(mRsp))
 	_, err := s.c.ListDatacenters()
 	s.Error(err)

--- a/profitbricks_test.go
+++ b/profitbricks_test.go
@@ -22,7 +22,9 @@ func (s *SuiteClient) Test_Retry() {
 			called++
 			switch called {
 			case 1:
-				return httpmock.NewBytesResponse(http.StatusTooManyRequests, []byte{}), nil
+				rsp := httpmock.NewBytesResponse(http.StatusTooManyRequests, []byte{})
+				rsp.Header.Set("Retry-After", "1") // Overruled by RetryMaxWaitTime of 2 ns
+				return rsp, nil
 			case 2:
 				return httpmock.NewBytesResponse(http.StatusBadGateway, []byte{}), nil
 			case 3:

--- a/profitbricks_test.go
+++ b/profitbricks_test.go
@@ -1,11 +1,12 @@
 package profitbricks
 
 import (
-	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/suite"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/suite"
 )
 
 type SuiteClient struct {

--- a/profitbricks_test.go
+++ b/profitbricks_test.go
@@ -1,0 +1,44 @@
+package profitbricks
+
+import (
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type SuiteClient struct {
+	ClientBaseSuite
+}
+
+func Test_Client(t *testing.T) {
+	suite.Run(t, new(SuiteClient))
+}
+func (s *SuiteClient) Test_Retry() {
+	called := 0
+	httpmock.RegisterResponder(http.MethodGet, `=~/?depth=10`,
+		func(*http.Request) (*http.Response, error) {
+			called++
+			switch called {
+			case 1:
+				return httpmock.NewBytesResponse(http.StatusTooManyRequests, []byte{}), nil
+			case 2:
+				return httpmock.NewBytesResponse(http.StatusBadGateway, []byte{}), nil
+			case 3:
+				return httpmock.NewBytesResponse(http.StatusGatewayTimeout, []byte{}), nil
+			}
+			// More response code
+			return httpmock.NewBytesResponse(http.StatusOK, []byte{}), nil
+		},
+	)
+	s.c.SetRetryCount(3)
+	// slower that 2 nano seconds will result in a wait time of max int nano seconds (caused by internal normalization
+	// in go resty
+	s.c.SetRetryWaitTime(2 * time.Nanosecond)
+	s.c.SetRetryMaxWaitTime(2 * time.Nanosecond)
+
+	err := s.c.GetOK("/", nil)
+	s.Error(err)
+	s.Equal(3, called)
+}


### PR DESCRIPTION
Also fix the logic in the Rate limit handling (by removing it), since
it would change global settings. Retry for rate limit responses will now
use the same default retry/backoff mechanism as the other retries.