### PR TITLE
Unwrap errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -5,6 +5,7 @@ is specific http status code or not.
 package profitbricks
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -39,15 +40,17 @@ func NewClientError(errType ClientErrorType, msg string) ClientError {
 }
 
 func IsClientErrorType(err error, errType ClientErrorType) bool {
-	if err, ok := err.(ClientError); ok {
-		return err.errType == errType
+	var clientErr ClientError
+	if errors.As(err, &clientErr) {
+		return clientErr.errType == errType
 	}
 	return false
 }
 
 func IsHttpStatus(err error, status int) bool {
-	if err, ok := err.(ApiError); ok {
-		return err.HttpStatusCode() == status
+	var apiErr ApiError
+	if errors.As(err, &apiErr) {
+		return apiErr.HttpStatusCode() == status
 	}
 	return false
 }

--- a/error_test.go
+++ b/error_test.go
@@ -2,6 +2,7 @@ package profitbricks
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -111,4 +112,12 @@ func (s *ErrorSuite) Test_BadGatewayError() {
 	s.Error(err)
 	s.Equal(body, err.(ApiError).Body())
 	s.Equal(1, httpmock.GetTotalCallCount())
+}
+
+func TestIsHttpStatusWrapped(t *testing.T) {
+	assert.True(t, IsHttpStatus(fmt.Errorf("wrapped: %w", newApiError(http.StatusOK)), http.StatusOK))
+}
+
+func TestIsClientErrorTypeWrapped(t *testing.T) {
+	assert.True(t, IsClientErrorType(fmt.Errorf("wrapped: %w", NewClientError(InvalidInput, "")), InvalidInput))
 }


### PR DESCRIPTION
Go 1.13 introduced the concept of unwrapping errors into the standard library (see: https://golang.org/pkg/errors). 