### PR TITLE
Add `Active` and `S3CanonicalUserID` to `UserProperties`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2068,7 +2068,7 @@ Retrieve details about a specific user including what groups and resources the u
 The following table describes the request arguments:
 
 | Name   | Required | Type   | Description                                                |
-| ------ | -------- | ------ | ---------------------------------------------------------- |
+| ------ | :------: | ------ | ---------------------------------------------------------- |
 | userid | **yes**  | string | The ID of the specific user to retrieve information about. |
 
 ```
@@ -2083,64 +2083,76 @@ Creates a new user under a particular contract.
 
 The following table describes the request arguments:
 
-| Name | Required | Type | Description                              |
-| ---- | -------- | ---- | ---------------------------------------- |
-| user | **yes**  | User | See [User Object](#user-resource-object) |
+| Name | Required | Type                          | Description     |
+| ---- | :------: | ----------------------------- | --------------- |
+| user | **yes**  | [User](#user-resource-object) | The user data.  |
 
 Build the `User` resource object:
 
-    var user = User{
-    	Properties: &UserProperties{
-    		Firstname:     "John",
-    		Lastname:      "Doe",
-    		Email:         email,
-    		Password:      "abc123-321CBA",
-    		Administrator: false,
-    		ForceSecAuth:  false,
-    		SecAuthActive: false,
-    	},
-    }
+```go
+user := User{
+    Properties: &UserProperties{
+        Firstname:     "John",
+        Lastname:      "Doe",
+        Email:         "test@go.com",
+        Password:      "abc123-321CBA",
+        Administrator: false,
+        ForceSecAuth:  false,
+        SecAuthActive: false,
+    },
+}
+```
 
 Pass the object to `CreateUser`:
 
-```
-CreateUser(user User)
+```go
+CreateUser(user)
 ```
 
 #### User Resource Object
 
-| Name          | Required | Type | Description                                                               |
-| ------------- | :------: | ---- | ------------------------------------------------------------------------- |
-| Firstname     | **yes**  | bool | The first name of the user.                                               |
-| Lastname      | **yes**  | bool | The last name of the user.                                                |
-| Email         | **yes**  | bool | The e-mail address of the user.                                           |
-| Password      | **yes**  | bool | A password for the user.                                                  |
-| Administrator |    no    | bool | Indicates if the user has administrative rights.                          |
-| ForceSecAuth  |    no    | bool | Indicates if secure (two-factor) authentication was enabled for the user. |
-| SecAuthActive |    no    | bool | Indicates if secure (two-factor) authentication is enabled for the user.  |
-
+| Name              | Required | Type  | Description                                                               |
+| ----------------- | :-----: | ------ | ------------------------------------------------------------------------- |
+| Firstname         | **yes** | string | The first name of the user.                                               |
+| Lastname          | **yes** | string | The last name of the user.                                                |
+| Email             | **yes** | string | The e-mail address of the user.                                           |
+| Password          | **yes** | string | A password for the user.                                                  |
+| Administrator     |    no   | bool   | Indicates if the user has administrative rights.                          |
+| ForceSecAuth      |    no   | bool   | Indicates if secure (two-factor) authentication was enabled for the user. |
+| SecAuthActive     |    no   | bool   | Indicates if secure (two-factor) authentication is enabled for the user.  |
+| Active            |    no   | *bool  | Indicates if the user is active (true) or disabled (false).               |
+| S3CanonicalUserID |    no   | string | The user's S3 ID.                                                         |
 ---
 
 #### Update a User
 
-Update details about a specific user including their privileges.
+Update details about a specific user including its privileges.
 
 The following table describes the request arguments:
 
-| Name   | Required | Type   | Description                            |
-| ------ | -------- | ------ | -------------------------------------- |
-| userid | **Yes**  | string | The ID of the specific user to update. |
+| Name   | Required | Type                          | Description                            |
+| ------ | :------: | ----------------------------- | -------------------------------------- |
+| userid | **yes**  | string                        | The ID of the specific user to update. |
+| user   | **yes**  | [User](#user-resource-object) | The user data.                         |
 
+```go
+t := true
+user := User{
+    Properties: &UserProperties{
+        Firstname:     "go sdk",
+        Lastname:      "newName",
+        Email:         "test@go.com",
+        Administrator: false,
+        ForceSecAuth:  false,
+        SecAuthActive: false,
+        Active:        &t,
+    },
+}
 ```
-user := UserProperties{
-		Firstname:     "go sdk ",
-		Lastname:      newName,
-		Email:         "test@go.com",
-		Password:      "abc123-321CBA",
-		Administrator: false,
-		ForceSecAuth:  false,
-		SecAuthActive: false,
-	}
+
+Pass the object to `UpdateUser`:
+
+```go
 UpdateUser(userid, user)
 ```
 
@@ -2153,10 +2165,10 @@ Blacklists the user, disabling them. The user is not completely purged, therefor
 The following table describes the request arguments:
 
 | Name   | Type    | Description | Required                               |
-| ------ | ------- | ----------- | -------------------------------------- |
-| userid | **Yes** | string      | The ID of the specific user to update. |
+| ------ | :-----: | ----------- | -------------------------------------- |
+| userid | **yes** | string      | The ID of the specific user to delete. |
 
-```
+```go
 DeleteUser(userid)
 ```
 

--- a/integration-tests/usermanagment_integration_test.go
+++ b/integration-tests/usermanagment_integration_test.go
@@ -78,7 +78,9 @@ func TestCreateUser(t *testing.T) {
 	assert.Equal(t, user.Properties.Firstname, "John")
 	assert.Equal(t, user.Properties.Lastname, "Doe")
 	assert.Equal(t, user.Properties.Email, email)
-	assert.True(t, user.Properties.Active)
+	if assert.NotNil(t, user.Properties.Active) {
+		assert.True(t, *user.Properties.Active)
+	}
 	assert.Equal(t, user.Properties.Administrator, false)
 	assert.NotEmpty(t, user.Properties.S3CanonicalUserID)
 }
@@ -123,7 +125,9 @@ func TestGetUser(t *testing.T) {
 	assert.Equal(t, resp.Properties.Firstname, "John")
 	assert.Equal(t, resp.Properties.Lastname, "Doe")
 	assert.Equal(t, resp.Properties.Email, email)
-	assert.True(t, resp.Properties.Active)
+	if assert.NotNil(t, resp.Properties.Active) {
+		assert.True(t, *resp.Properties.Active)
+	}
 	assert.Equal(t, resp.Properties.Administrator, false)
 	assert.Equal(t, resp.PBType, "user")
 	assert.NotEmpty(t, resp.Properties.S3CanonicalUserID)

--- a/integration-tests/usermanagment_integration_test.go
+++ b/integration-tests/usermanagment_integration_test.go
@@ -80,6 +80,7 @@ func TestCreateUser(t *testing.T) {
 	assert.Equal(t, user.Properties.Email, email)
 	assert.True(t, user.Properties.Active)
 	assert.Equal(t, user.Properties.Administrator, false)
+	assert.NotEmpty(t, user.Properties.S3CanonicalUserID)
 }
 
 func TestCreateUserFailure(t *testing.T) {
@@ -125,6 +126,7 @@ func TestGetUser(t *testing.T) {
 	assert.True(t, resp.Properties.Active)
 	assert.Equal(t, resp.Properties.Administrator, false)
 	assert.Equal(t, resp.PBType, "user")
+	assert.NotEmpty(t, resp.Properties.S3CanonicalUserID)
 }
 
 func TestUpdateUser(t *testing.T) {

--- a/integration-tests/usermanagment_integration_test.go
+++ b/integration-tests/usermanagment_integration_test.go
@@ -78,6 +78,7 @@ func TestCreateUser(t *testing.T) {
 	assert.Equal(t, user.Properties.Firstname, "John")
 	assert.Equal(t, user.Properties.Lastname, "Doe")
 	assert.Equal(t, user.Properties.Email, email)
+	assert.True(t, user.Properties.Active)
 	assert.Equal(t, user.Properties.Administrator, false)
 }
 
@@ -121,6 +122,7 @@ func TestGetUser(t *testing.T) {
 	assert.Equal(t, resp.Properties.Firstname, "John")
 	assert.Equal(t, resp.Properties.Lastname, "Doe")
 	assert.Equal(t, resp.Properties.Email, email)
+	assert.True(t, resp.Properties.Active)
 	assert.Equal(t, resp.Properties.Administrator, false)
 	assert.Equal(t, resp.PBType, "user")
 }

--- a/usermanagment.go
+++ b/usermanagment.go
@@ -80,7 +80,7 @@ type UserProperties struct {
 	Administrator     bool   `json:"administrator,omitempty"`
 	ForceSecAuth      bool   `json:"forceSecAuth,omitempty"`
 	SecAuthActive     bool   `json:"secAuthActive,omitempty"`
-	Active            bool   `json:"active,omitempty"`
+	Active            *bool  `json:"active,omitempty"`
 	S3CanonicalUserID string `json:"s3CanonicalUserId,omitempty"`
 }
 

--- a/usermanagment.go
+++ b/usermanagment.go
@@ -73,13 +73,15 @@ type User struct {
 
 // UserProperties object
 type UserProperties struct {
-	Firstname     string `json:"firstname,omitempty"`
-	Lastname      string `json:"lastname,omitempty"`
-	Email         string `json:"email,omitempty"`
-	Password      string `json:"password,omitempty"`
-	Administrator bool   `json:"administrator,omitempty"`
-	ForceSecAuth  bool   `json:"forceSecAuth,omitempty"`
-	SecAuthActive bool   `json:"secAuthActive,omitempty"`
+	Firstname         string `json:"firstname,omitempty"`
+	Lastname          string `json:"lastname,omitempty"`
+	Email             string `json:"email,omitempty"`
+	Password          string `json:"password,omitempty"`
+	Administrator     bool   `json:"administrator,omitempty"`
+	ForceSecAuth      bool   `json:"forceSecAuth,omitempty"`
+	SecAuthActive     bool   `json:"secAuthActive,omitempty"`
+	Active            bool   `json:"active,omitempty"`
+	S3CanonicalUserID string `json:"s3CanonicalUserId,omitempty"`
 }
 
 // UserEntities object


### PR DESCRIPTION
The `Active` field was forgotten in the API's swagger document.
The API team confirmed that the field can be relied on, though.
A bug was filed regarding the incomplete swagger doc.

The `S3CanonicalUserID` field was just missing in the SDK.