### PR TITLE
Fixes retry behavior for writing requests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4Hmx
 github.com/jarcoal/httpmock v1.0.5 h1:cHtVEcTxRSX4J0je7mWPfc9BpDpqzXSJ5HbymZmyHck=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -26,7 +25,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/profitbricks.go
+++ b/profitbricks.go
@@ -57,7 +57,6 @@ func RestyClient(username, password, token string) *Client {
 	})
 	c.AddRetryCondition(
 		func(r *resty.Response, err error) bool {
-			// Only retry on read-only requests
 			switch r.StatusCode() {
 			case http.StatusTooManyRequests:
 				return true

--- a/profitbricks.go
+++ b/profitbricks.go
@@ -53,6 +53,7 @@ func RestyClient(username, password, token string) *Client {
 			// Only retry on read-only requests
 			if r.Request.Method != http.MethodGet &&
 				r.Request.Method != http.MethodHead &&
+				r.Request.Method != http.MethodTrace &&
 				r.Request.Method != http.MethodOptions {
 				return false
 			}

--- a/profitbricks.go
+++ b/profitbricks.go
@@ -50,6 +50,12 @@ func RestyClient(username, password, token string) *Client {
 	})
 	c.AddRetryCondition(
 		func(r *resty.Response, err error) bool {
+			// Only retry on read-only requests
+			if r.Request.Method != http.MethodGet &&
+				r.Request.Method != http.MethodHead &&
+				r.Request.Method != http.MethodOptions {
+				return false
+			}
 			switch r.StatusCode() {
 			case http.StatusTooManyRequests,
 				http.StatusServiceUnavailable,

--- a/profitbricks_test.go
+++ b/profitbricks_test.go
@@ -41,7 +41,7 @@ func (s *SuiteClient) Test_Retry() {
 		},
 	)
 	s.c.SetRetryCount(3)
-	// slower that 2 nano seconds will result in a wait time of max int nano seconds (caused by internal normalization
+	// slower than 2 nano seconds will result in a wait time of max int nanoseconds (caused by internal normalization)
 	// in go resty
 	s.c.SetRetryWaitTime(2 * time.Nanosecond)
 	s.c.SetRetryMaxWaitTime(2 * time.Nanosecond)
@@ -69,7 +69,7 @@ func (s *SuiteClient) Test_NoRetryOnWrite() {
 		},
 	)
 	s.c.SetRetryCount(3)
-	// slower that 2 nano seconds will result in a wait time of max int nano seconds (caused by internal normalization
+	// slower than 2 nano seconds will result in a wait time of max int nanoseconds (caused by internal normalization)
 	// in go resty
 	s.c.SetRetryWaitTime(2 * time.Nanosecond)
 	s.c.SetRetryMaxWaitTime(2 * time.Nanosecond)
@@ -78,4 +78,3 @@ func (s *SuiteClient) Test_NoRetryOnWrite() {
 	s.NoError(err) // Error is expected by Post Call
 	s.Equal(2, called)
 }
-

--- a/profitbricks_test.go
+++ b/profitbricks_test.go
@@ -16,6 +16,7 @@ type SuiteClient struct {
 func Test_Client(t *testing.T) {
 	suite.Run(t, new(SuiteClient))
 }
+
 func (s *SuiteClient) Test_Retry() {
 	called := 0
 	httpmock.RegisterResponder(http.MethodGet, `=~/?depth=10`,
@@ -49,3 +50,32 @@ func (s *SuiteClient) Test_Retry() {
 	s.Error(err)
 	s.Equal(4, called)
 }
+
+func (s *SuiteClient) Test_NoRetryOnWrite() {
+	called := 0
+	httpmock.RegisterResponder(http.MethodPost, `=~/?depth=10`,
+		func(*http.Request) (*http.Response, error) {
+			called++
+			switch called {
+			case 1:
+				rsp := httpmock.NewBytesResponse(http.StatusTooManyRequests, []byte{})
+				rsp.Header.Set("Retry-After", "1") // Overruled by RetryMaxWaitTime of 2 ns
+				return rsp, nil
+			case 2:
+				return httpmock.NewBytesResponse(http.StatusBadGateway, []byte{}), nil
+			}
+			// More response code
+			return httpmock.NewBytesResponse(http.StatusOK, []byte{}), nil
+		},
+	)
+	s.c.SetRetryCount(3)
+	// slower that 2 nano seconds will result in a wait time of max int nano seconds (caused by internal normalization
+	// in go resty
+	s.c.SetRetryWaitTime(2 * time.Nanosecond)
+	s.c.SetRetryMaxWaitTime(2 * time.Nanosecond)
+
+	err := s.c.Post("/", nil, nil, http.StatusBadGateway)
+	s.NoError(err) // Error is expected by Post Call
+	s.Equal(2, called)
+}
+


### PR DESCRIPTION
Write request failures won't be retried now, as this lead to
unexpected behaviour. Read-Only requests will be still retried
on server side errors.