### PR TITLE
remove user defined retries on non-existing header

### DIFF
--- a/profitbricks.go
+++ b/profitbricks.go
@@ -46,15 +46,6 @@ func RestyClient(username, password, token string) *Client {
 	c.SetRetryCount(3)
 	c.SetRetryMaxWaitTime(10 * time.Minute)
 	c.SetRetryWaitTime(1 * time.Second)
-	c.SetRetryAfter(func(cl *resty.Client, r *resty.Response) (time.Duration, error) {
-		switch r.StatusCode() {
-		case http.StatusTooManyRequests:
-			if retryAfterSeconds := r.Header().Get("Retry-After"); retryAfterSeconds != "" {
-				return time.ParseDuration(retryAfterSeconds + "s")
-			}
-		}
-		return cl.RetryWaitTime, nil
-	})
 	c.AddRetryCondition(
 		func(r *resty.Response, err error) bool {
 			switch r.StatusCode() {


### PR DESCRIPTION
Since the retry-after header might be returning empty values on the API we should go back to using resty's builtin backoff approach:

https://github.com/go-resty/resty/blob/3d08b3602d13ae8a44f246db2ec34402e18497c6/README.md#retries
https://github.com/go-resty/resty/blob/b8f7c11e7ffbd132c6743f16d784ee7164a883ba/retry.go#L168